### PR TITLE
Fix password verification and ESGF schema/table name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # Settings
 settings.py
+
+.idea
+docker-entrypoint.py

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ settings.py
 
 .idea
 docker-entrypoint.py
+.DS_Store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.txt *.md *.py
 recursive-include esgf_auth *.py
 recursive-include esgf_slcs_server *.py
+recursive-include esgf_slcs_server/templates *.html
 recursive-include onlineca *.py

--- a/esgf_auth/backend.py
+++ b/esgf_auth/backend.py
@@ -25,7 +25,7 @@ class EsgfUserBackend(ModelBackend):
         # Try to retrieve a row from the ESGF user database with the given
         # username and password
         with connections['userdb'].cursor() as cursor:
-            cursor.execute('SELECT * FROM "esgf_security.user" '
+            cursor.execute('SELECT * FROM esgf_security.user '
                            'WHERE username = %s AND password = MD5(%s)', (username, password))
             has_esgf_user = cursor.fetchone() is not None
         # If there is no ESGF user matching the username/password, we are done

--- a/esgf_auth/backend.py
+++ b/esgf_auth/backend.py
@@ -7,10 +7,12 @@ ESGF user database.
 __author__ = "Matt Pryor"
 __copyright__ = "Copyright 2016 UK Science and Technology Facilities Council"
 
+from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth import get_user_model
 from django.db import connections
 from passlib.hash import md5_crypt
+from psycopg2 import sql
 
 
 class EsgfUserBackend(ModelBackend):
@@ -26,8 +28,8 @@ class EsgfUserBackend(ModelBackend):
         # Try to retrieve a row from the ESGF user database with the given
         # username and password
         with connections['userdb'].cursor() as cursor:
-            cursor.execute('SELECT password FROM esgf_security.user '
-                           'WHERE username = %s', [username])
+            cursor.execute(sql.SQL("SELECT password FROM {} WHERE username = %s")
+                           .format(sql.Identifier(settings.ESGF_USERDB_USER_TABLE)), [username])
             row = cursor.fetchone()
 
             # Check if user exists

--- a/esgf_auth/openid.py
+++ b/esgf_auth/openid.py
@@ -11,5 +11,5 @@ def django_user_to_openid(user):
     Converts a Django user to an OpenID using information in the ESGF user database.
     """
     with connections['userdb'].cursor() as cursor:
-        cursor.execute('SELECT openid FROM "esgf_security.user" WHERE username = %s', [user.username])
+        cursor.execute('SELECT openid FROM esgf_security.user WHERE username = %s', [user.username])
         return cursor.fetchone()[0]

--- a/esgf_auth/openid.py
+++ b/esgf_auth/openid.py
@@ -4,6 +4,8 @@ This module contains utility functions for OpenID handling.
 """
 
 from django.db import connections
+from django.conf import settings
+from psycopg2 import sql
 
 
 def django_user_to_openid(user):
@@ -11,5 +13,8 @@ def django_user_to_openid(user):
     Converts a Django user to an OpenID using information in the ESGF user database.
     """
     with connections['userdb'].cursor() as cursor:
-        cursor.execute('SELECT openid FROM esgf_security.user WHERE username = %s', [user.username])
+        cursor.execute(sql.SQL("SELECT openid FROM {}.{} WHERE username = %s")
+                       .format(sql.Identifier(settings.ESGF_USERDB_USER_SCHEMA),
+                               sql.Identifier(settings.ESGF_USERDB_USER_TABLE)),
+                       [user.username])
         return cursor.fetchone()[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18
 oauthlib==2.0.1
+passlib==1.6.5
 packaging==16.8
 Paste==2.0.3
 PasteDeploy==1.5.2


### PR DESCRIPTION
This PR fixes two issues:

First, ESGF COG uses the  passlib `md5_crypt` python library to hash passwords
 
https://github.com/EarthSystemCoG/COG/blob/master/cog/plugins/esgf/security.py#L229
 
Updated `esgf_auth.backend.authenticate()` to use passlib `md5_crypt` so it matches how COG does it.

---

Second, double quotes around `“esgf_security.user”` in the SQL queries can cause issues. esgf-docker user table is created as `“user”`. The double quotes around the schema and table name in the query were causing a failure to find the existing table. 

The fix is to actually extract the schema name and table name into Django settings so that I could dynamically set them for the query. See changes in `backend.py` and `openid.py`.

**SUPER IMPORTANT NOTE:** This PR adds the expectation that both `settings.ESGF_USERDB_USER_SCHEMA` and `settings.ESGF_USERDB_USER_TABLE` are defined in `settings.py`. That means the current Ansible deployment needs to be updated to define these settings in order for it to still work.